### PR TITLE
fixed compile warning introduced by new clang/GCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 This project adheres to [semantic versioning](https://semver.org/).
+# 2.0.3 (2022-05-02)
+***
+### Release Highlights
+* Fixed compile error caused by newest varion of GCC/Clang that prevented compilation in optimized mode due to an extraneous warning flag.
 # 2.0.2 (2021-02-27)
 ***
 ### Release Highlights

--- a/notarook-ie/Makefile
+++ b/notarook-ie/Makefile
@@ -7,7 +7,7 @@
 # why so many warnings flags? because it's good practice to be warning and error free
 # the -Werror flag turns any compiler warnings into errors, stopping compilation
 C_FLAGS   = -c -std=c99 -pedantic -Wall -Wextra -D__EXTENSIONS__
-OPT       = -O3 -Werror
+OPT       = -O3 -Werror -Wno-unused-but-set-variable
 D_FLAG    = -g
 LD_FLAGS  = -Wall -Wextra
 EXE       = notarookie

--- a/notarook-ie/constants.h
+++ b/notarook-ie/constants.h
@@ -47,6 +47,16 @@
  * that no matter what OS runs this code, the size will be the same.
  */
 
+//#define DEBUG
+
+// kind of messy, but this whole mess allows us to throw in
+// assert debug statements without mass commenting them out later
+// just comment out line 50
+// to be clear, I took this from a book and didn't come up with this macro
+// myself
+#ifndef DEBUG
+#define ASSERT(n)
+#else
 #define ASSERT(n) \
 if(!(n)) { \
 printf("%s - \033[91mFAILED!!\033[0m", #n); \
@@ -55,6 +65,7 @@ printf("at %s ", __TIME__); \
 printf("in file %s ", __FILE__); \
 printf("on line %d\n", __LINE__); \
 exit(1);}
+#endif
 
 
 #define NAME "NotARook-ie v2.0.2"

--- a/notarook-ie/constants.h
+++ b/notarook-ie/constants.h
@@ -68,7 +68,7 @@ exit(1);}
 #endif
 
 
-#define NAME "NotARook-ie v2.0.2"
+#define NAME "NotARook-ie v2.0.3"
 
 #define START_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 


### PR DESCRIPTION
When compiling with optimizations, the `ASSERT` macro ([defined here](https://github.com/nate-browne/NotARook-ie/blob/master/notarook-ie/constants.h#L50-L57)) caused a compile failure due to the `-Wunused-but-set-variable` warning flag. This PR just makes it so that when compiling in optimized mode, that warning is ignored.